### PR TITLE
Agregar traducción para "All rigths reserved."

### DIFF
--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -26,5 +26,6 @@
     "A fresh verification link has been sent to your email address.": "Se ha enviado un nuevo enlace de verificación a tu correo electrónico.",
     "Before proceeding, please check your email for a verification link.": "Antes de poder continuar, por favor, confirma tu correo electrónico con el enlace que te hemos enviado.",
     "If you did not receive the email": "Si no has recibido el email",
-    "click here to request another": "pulsa aquí para que te enviemos otro"
+    "click here to request another": "pulsa aquí para que te enviemos otro",
+    "All rights reserved.":  "Todos los derechos reservados."
 }


### PR DESCRIPTION
[Este PR realizado al framework](https://github.com/laravel/framework/pull/25183) introdujo la posibilidad de traducir el mensaje de copyright "All right reserved.", mensaje utilizado en el footer de los emails estructurados con Markdown.

Con este PR se agrega la traducción para dicha frase.