### PR TITLE
Traduce textos de páginas de errores y textos Laravel 8 (Breeze)

### DIFF
--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -50,6 +50,7 @@
     "Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\\'t receive the email, we will gladly send you another.": "¡Gracias por registrarte! Antes de empezar, ¿Podrías verificar tu email haciendo click en el enlace que te acabamos de enviar? Si no recibes el email, con gusto te enviaremos otro.",
     "A new verification link has been sent to the email address you provided during registration.": "Un nuevo enlace de verificación ha sido enviado al email que nos diste durante el registro.",
     "Resend Verification Email": "Reenviar email de verificación",
-    "Log out": "Cerrar sesión"
+    "Log out": "Cerrar sesión",
+    "Dashboard": "Tablero"
 
 }

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -29,5 +29,13 @@
     "Before proceeding, please check your email for a verification link.": "Antes de poder continuar, por favor, confirma tu correo electrónico con el enlace que te hemos enviado.",
     "If you did not receive the email": "Si no has recibido el email",
     "click here to request another": "pulsa aquí para que te enviemos otro",
-    "All rights reserved.":  "Todos los derechos reservados."
+    "All rights reserved.":  "Todos los derechos reservados.",
+    "Service Unavailable": "Servicio no disponible",
+    "Server Error": "Error en el servidor",
+    "Too Many Requests": "Demasiadas peticiones",
+    "Page Expired": "Página expirada",
+    "Forbidden": "Prohibido",
+    "Unauthorized": "Sin autorización",
+    "Not Found": "No encontrado"
+
 }

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -36,6 +36,20 @@
     "Page Expired": "Página expirada",
     "Forbidden": "Prohibido",
     "Unauthorized": "Sin autorización",
-    "Not Found": "No encontrado"
+    "Not Found": "No encontrado",
+    "Whoops! Something went wrong.": "¡Ups! Algo anduvo mal.",
+    "This is a secure area of the application. Please confirm your password before continuing.": "Esta es una área segura de la aplicación. Por favor confirma tu contraseña antes de continuar.",
+    "Confirm": "Confirmar",
+    "Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.": "¿Olvidaste tu contraseña? No hay problema. Sólo dinos tu email y te enviaremos un enlace para reestablecer la contraseña, el cual te permitirá escoger una nueva.",
+    "Email Password Reset Link": "Enlace para reestablecer la contraseña",
+    "Email": "Correo electrónico",
+    "Remember me": "Recuérdame",
+    "Forgot your password?": "¿Olvidaste tu contraseña?",
+    "Log in": "Acceder",
+    "Already registered?": "¿Ya estás registrado?",
+    "Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\\'t receive the email, we will gladly send you another.": "¡Gracias por registrarte! Antes de empezar, ¿Podrías verificar tu email haciendo click en el enlace que te acabamos de enviar? Si no recibes el email, con gusto te enviaremos otro.",
+    "A new verification link has been sent to the email address you provided during registration.": "Un nuevo enlace de verificación ha sido enviado al email que nos diste durante el registro.",
+    "Resend Verification Email": "Reenviar email de verificación",
+    "Log out": "Cerrar sesión"
 
 }

--- a/resources/lang/es/auth.php
+++ b/resources/lang/es/auth.php
@@ -14,6 +14,7 @@ return [
     */
 
     'failed' => 'Estas credenciales no coinciden con nuestros registros.',
+    'password' => 'La contraseña ingresada es incorrecta.',
     'throttle' => 'Demasiados intentos de acceso. Por favor inténtelo de nuevo en :seconds segundos.',
 
 ];

--- a/resources/lang/es/passwords.php
+++ b/resources/lang/es/passwords.php
@@ -18,5 +18,4 @@ return [
     'token' => 'Este token de restablecimiento de contraseña es inválido.',
     'user' => 'No se ha encontrado un usuario con esa dirección de correo.',
     'throttled' => 'Por favor espere antes de volver a intentarlo.',
-    'password' => 'Las contraseñas deben tener al menos seis caracteres y coincidir con la confirmación.'
 ];

--- a/resources/lang/es/validation.php
+++ b/resources/lang/es/validation.php
@@ -90,6 +90,7 @@ return [
         'string'  => 'El campo :attribute debe contener al menos :min caracteres.',
         'array'   => 'El campo :attribute debe contener al menos :min elementos.',
     ],
+    'multiple_of'          => 'El campo :attribute debe ser múltiplo de :value.',
     'not_in'               => 'El campo :attribute seleccionado es inválido.',
     'not_regex'            => 'El formato del campo :attribute es inválido.',
     'numeric'              => 'El campo :attribute debe ser un número.',


### PR DESCRIPTION
Traduce textos de páginas de errores como Not Found, Unauthorized, etc.

También agrega nuevos textos hasta la versión Laravel 8 y Laravel Breeze.