### PR TITLE
Agregados los strings de la paginación con Tailwind

### DIFF
--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -29,5 +29,9 @@
     "Before proceeding, please check your email for a verification link.": "Antes de poder continuar, por favor, confirma tu correo electrónico con el enlace que te hemos enviado.",
     "If you did not receive the email": "Si no has recibido el email",
     "click here to request another": "pulsa aquí para que te enviemos otro",
-    "All rights reserved.":  "Todos los derechos reservados."
+    "All rights reserved.":  "Todos los derechos reservados.",
+    "Showing": "Mostrando desde el",
+    "to" : "al",
+    "of" : "de",
+    "results" : "resultados"
 }


### PR DESCRIPTION
He agregado los strings que faltan cuando utilizamos la paginación con Tailwind.

Dichos strings aparecen [aquí](https://github.com/laravel/framework/blob/130168c9dcd399f6b42bccfe4882b88c81a4edfe/src/Illuminate/Pagination/resources/views/tailwind.blade.php#L28-L34).